### PR TITLE
** Recently Viewed Pages **

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -54,7 +54,7 @@
 				<key>argumenttrimmode</key>
 				<integer>0</integer>
 				<key>argumenttype</key>
-				<integer>0</integer>
+				<integer>1</integer>
 				<key>escaping</key>
 				<integer>68</integer>
 				<key>keyword</key>
@@ -68,9 +68,9 @@
 				<key>queuemode</key>
 				<integer>1</integer>
 				<key>runningsubtext</key>
-				<string></string>
+				<string>Loading..</string>
 				<key>script</key>
-				<string>PYTHONIOENCODING=UTF-8 python notion.py "{query}"</string>
+				<string>python3 notion.py "{query}"</string>
 				<key>scriptargtype</key>
 				<integer>0</integer>
 				<key>scriptfile</key>
@@ -262,7 +262,7 @@ Thanks!</string>
 		<string>notionSpaceId</string>
 	</array>
 	<key>version</key>
-	<string>0.3.3</string>
+	<string>0.4.0</string>
 	<key>webaddress</key>
 	<string>https://willlewis.co.uk</string>
 </dict>


### PR DESCRIPTION
** Recently Viewed Pages ** Your most recently viewed notion pages are shown when triggering the workflow. Simply type the 'ns' keyword to start the workflow, as you would before you search, and your most recently viewed notion pages are displayed.

The workflow has been migrated to Python3 - ensuring compatibility with future versions of MacOS: "Python 2.7 was removed from macOS [12.3]. Developers should use Python 3 or an alternative language instead. (39795874)"

Fixed issue with no results in certain circumstances with collections/dbs

Fixed issue with null highlight on non-page elements - thanks to @ymszzq

Fixed issue retrieving and displaying notion icons in results, due to change in internal notion APIs

Fixed issue where externally hosted icons wouldn't show in results

Slightly better error handling when no results are returned

Results returned from Notion will now be shown in the original order, bypassing Alfred's learning algorithm.

(Unfortunately this workflow is not using the public notion api yet, which means you still have to retrieve your cookie/token manually. The public notion api is still in beta and I believe it doesn't have the same functionality compared to the internal api, but it is improving month on month. If anyone would like to give it a go adapting this workflow to use the api, I'll gratefully review any PRs).