### PR TITLE
chore(ReadMe): add note on retrieving cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Includes the ability to quickly see your recently viewed pages which are shown w
 
 ## Obtaining your workflow variables
 
+> **Note**: Using the webapp is important, the Mac OS app for example will hide the cookies.
+
 Visit the Notion webapp and use your browser developer tools to see the network requests being made when you type in anything to the quick find search bar. 
 
 Here you'll see a request called `search`, check the request headers to copy the `cookie` value and check the request payload to copy your `notionSpaceId`.


### PR DESCRIPTION
It wasn't immediately obvious to me until I saw a github issue (https://github.com/wrjlewis/notion-search-alfred-workflow/issues/24) of the same suggesting the mac app doesn't allow viewing the cookies, so I added a note that makes this part clearer