### PR TITLE
update version and isNavigableOnly to false

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -250,7 +250,7 @@ Thanks!</string>
 		<key>enableIcons</key>
 		<string>True</string>
 		<key>isNavigableOnly</key>
-		<string>True</string>
+		<string>False</string>
 		<key>notionSpaceId</key>
 		<string></string>
 		<key>showRecentlyViewedPages</key>
@@ -260,11 +260,11 @@ Thanks!</string>
 	</dict>
 	<key>variablesdontexport</key>
 	<array>
-		<string>cookie</string>
 		<string>notionSpaceId</string>
+		<string>cookie</string>
 	</array>
 	<key>version</key>
-	<string>0.4.1</string>
+	<string>0.4.2</string>
 	<key>webaddress</key>
 	<string>https://willlewis.co.uk</string>
 </dict>


### PR DESCRIPTION
Updating version number, with recent api changes
Changing isNavigableOnly to False, since you can only get subtitles in the search results when this is False, resulting from changes on Notions side. You still have the option to set this to True, but you will lose subtitles in the Alfred search results. 