### PR TITLE
0.6-alfred4 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,13 @@ Pressing enter on a search result takes you to that page in Notion in your defau
 
 Hold Cmd + press enter on any search result to copy the url to your clipboard. 
 
-Comes with pre-configured support for [OneUpdater](https://github.com/vitorgalvao/alfred-workflows/tree/master/OneUpdater) for automatic version updates.
+**Additional features**
 
-The workflow also provides the ability to quickly see your __recently viewed pages__. Simply type the 'ns' keyword to start the workflow, as you would before you search, and your most recently viewed notion pages are displayed. 
+* Comes with pre-configured support for [OneUpdater](https://github.com/vitorgalvao/alfred-workflows/tree/master/OneUpdater) for automatic version updates.
+
+* The workflow also provides the ability to quickly see your __recently viewed pages__. Simply type the 'ns' keyword to start the workflow, as you would before you search, and your most recently viewed notion pages are displayed. 
+
+* Open a new notion page by typing 'nsn', this only supports the web app currently, it's very handy!
 
 ![img](https://raw.githubusercontent.com/wrjlewis/notion-search-alfred5-workflow/main/alfred%20notion%20search.gif)
 
@@ -47,8 +51,6 @@ Many people will have Python3 already on their machine, if you haven't you can t
 
 Otherwise you can read a more detailed guide on installing Python [here](https://docs.python-guide.org/starting/install3/osx/). 
 
-
-
 ### Install cairosvg (optional)
 
 Installing cairosvg will allow svg icons to be shown in Alfred search results, providing a more visually appealing experience. Open terminal and run the following command:
@@ -59,7 +61,17 @@ Install cairosvgs's dependency, cairo. With [Homebrew](https://brew.sh/) for exa
 
 `brew install cairo`
 
-If you haven't used homebrew before, you may want to skip this optional step.
+If you haven't used homebrew before, you may want to skip this optional step or install homebrew (easy with a quick google search).
+
+UPDATE: There seems to be an issue with cairosvg on apple silicon, use this fix at your own risk but this worked for me and now SVG icons show again:
+
+```
+brew install cairo pango gdk-pixbuf libxml2 libxslt libffi
+sudo mkdir /usr/local/lib/
+sudo ln -s /opt/homebrew/lib/libcairo-2.dll /usr/local/lib/libcairo-2.dll
+sudo ln -s /opt/homebrew/lib/libcairo.so.2 /usr/local/lib/libcairo.so.2
+sudo ln -s /opt/homebrew/lib/libcairo.2.dylib /usr/local/lib/libcairo.2.dylib
+```
 
 ### Get your workflow variables
 

--- a/info.plist
+++ b/info.plist
@@ -39,6 +39,19 @@
 				<false/>
 			</dict>
 		</array>
+		<key>F7D08518-1D55-4B69-AE6C-198FA8628A43</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>0B599F73-39AE-445B-8B09-AA12331F953D</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
 	</dict>
 	<key>createdby</key>
 	<string>Will Lewis</string>
@@ -234,9 +247,56 @@ fi</string>
 			<key>version</key>
 			<integer>3</integer>
 		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>argumenttype</key>
+				<integer>2</integer>
+				<key>keyword</key>
+				<string>nsn</string>
+				<key>subtext</key>
+				<string></string>
+				<key>text</key>
+				<string>Open a new Notion page..</string>
+				<key>withspace</key>
+				<false/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.keyword</string>
+			<key>uid</key>
+			<string>F7D08518-1D55-4B69-AE6C-198FA8628A43</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>browser</key>
+				<string></string>
+				<key>spaces</key>
+				<string></string>
+				<key>url</key>
+				<string>https://notion.new</string>
+				<key>utf8</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.openurl</string>
+			<key>uid</key>
+			<string>0B599F73-39AE-445B-8B09-AA12331F953D</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
 	</array>
 	<key>readme</key>
-	<string>****** PLEASE NOTE ******
+	<string>Latest updates in 0.6:
+
+- Updated cairosvg installation instructions in the readme: run the provided commands in order to get svg icons working on apple silicon.
+- Type ‘nsn’ for the option to quickly open a new page in Notion. Very handy! (This only works in the web app currently)
+- https://github.com/wrjlewis/notion-search-alfred-workflow/issues/83 - Fixed a bug that would cause an error and no more results to be displayed when opening pages relating to new Notion projects and icons.
+
+
+****** PLEASE NOTE ******
 
 Alfred 5 download now available here:
 
@@ -246,9 +306,7 @@ Usual automatic updates will follow once you've updated to the Alfred 5 version 
 
 If you are on alfred 4, you do not need to do anything and updates will continue as usual. 
 
-
-****** PLEASE NOTE ******
-
+---
 
 notion-search-alfred-workflow
 An Alfred workflow to search Notion.so with instant results
@@ -264,6 +322,13 @@ https://www.alfredforum.com/topic/14451-notionso-instant-search-workflow/
 Thanks!</string>
 	<key>uidata</key>
 	<dict>
+		<key>0B599F73-39AE-445B-8B09-AA12331F953D</key>
+		<dict>
+			<key>xpos</key>
+			<integer>255</integer>
+			<key>ypos</key>
+			<integer>480</integer>
+		</dict>
 		<key>2A617635-BC53-4025-A598-0A8B1E6C434B</key>
 		<dict>
 			<key>xpos</key>
@@ -288,6 +353,13 @@ Thanks!</string>
 			<real>255</real>
 			<key>ypos</key>
 			<real>175</real>
+		</dict>
+		<key>F7D08518-1D55-4B69-AE6C-198FA8628A43</key>
+		<dict>
+			<key>xpos</key>
+			<integer>65</integer>
+			<key>ypos</key>
+			<integer>480</integer>
 		</dict>
 		<key>FCE03E9D-F992-4B21-9A77-E72D5130DF80</key>
 		<dict>
@@ -316,11 +388,11 @@ Thanks!</string>
 	</dict>
 	<key>variablesdontexport</key>
 	<array>
-		<string>notionSpaceId</string>
 		<string>cookie</string>
+		<string>notionSpaceId</string>
 	</array>
 	<key>version</key>
-	<string>0.5.3-alfred4</string>
+	<string>0.6-alfred4</string>
 	<key>webaddress</key>
 	<string>https://github.com/wrjlewis/notion-search-alfred-workflow/</string>
 </dict>

--- a/notion.py
+++ b/notion.py
@@ -341,7 +341,9 @@ else:
                     else:
                         if searchResults.recordMap.get('block').get(searchResultObject.id).get('value').get('type') == "collection_view":
                             collectionPointerId = searchResults.recordMap.get('block').get(searchResultObject.id).get('value').get('format').get('collection_pointer').get('id')
-                            searchResultObject.icon = geticonpath(searchResultObject.id, searchResults.recordMap.get('collection').get(collectionPointerId).get('value').get('icon'))
+                            iconUrl = searchResults.recordMap.get('collection').get(collectionPointerId).get('value').get('icon')
+                            if iconUrl is not None:
+                                searchResultObject.icon = geticonpath(searchResultObject.id, searchResults.recordMap.get('collection').get(collectionPointerId).get('value').get('icon'))
                 else:
                     searchResultObject.icon = None
                     searchResultObject.title = searchResultObject.title
@@ -388,3 +390,4 @@ if not itemList:
 items = {}
 items["items"] = itemList
 items_json = json.dumps(items)
+sys.stdout.write(items_json)


### PR DESCRIPTION
- Type ‘nsn’ for the option to quickly open a new page in Notion. Very handy! (Only supports the web app currently)
- https://github.com/wrjlewis/notion-search-alfred-workflow/issues/83 - Fixed a bug that would cause an error and no more results to be displayed, relating to new Notion projects and icons.
- Update readme with:
    - new notion page functionality (only supports web app)
    - new cairo instructions for those on apple silicon, use at your own risk but they work for me and svg icons now appear in search results.